### PR TITLE
run this on gke

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=builder /home/builder/spigot-${SPIGOT_REV}.jar /jars/spigot.jar
 RUN chmod +x /jars/spigot.jar
 
 WORKDIR /home/minecraft/server
-CMD ["/sbin/tini", "-g", "--", "java", "-Xmx6G", "-Xms6G", "-XX:-UseContainerSupport", "-jar", "/jars/spigot.jar", "nogui"]
+CMD ["/sbin/tini", "-g", "--", "java", "-Xmx5G", "-Xms5G", "-XX:-UseContainerSupport", "-jar", "/jars/spigot.jar", "nogui"]

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -30,8 +30,8 @@ spec:
           name: mc
         resources:
           requests:
-            cpu: 1500m
-            memory: 5.5Gi
+            cpu: 1200m
+            memory: 5Gi
           limits:
             cpu: 1500m
             memory: 5.5Gi

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: spigot-server
+  labels:
+    name: spigot-server
+    app: "spigot-server"
+    env: "production"
+spec:
+  progressDeadlineSeconds: 120
+  replicas: 1
+  selector:
+    matchLabels:
+      name: spigot-server
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: spigot-server
+        app: "spigot-server"
+        env: "production"
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - name: spigot-server
+        image: gcr.io/perfect-chalice-250601/spigot-server:latest
+        ports:
+        - containerPort: 25565
+          name: mc
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 5.5Gi
+          limits:
+            cpu: 1500m
+            memory: 5.5Gi
+        volumeMounts:
+        - name: minecraft-map
+          mountPath: "/home/minecraft/server"
+          readOnly: false
+      volumes:
+      - name: minecraft-map
+        persistentVolumeClaim:
+          claimName: minecraft-map-volume

--- a/k8s/shell
+++ b/k8s/shell
@@ -1,0 +1,21 @@
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tmp
+spec:
+  containers:
+  - name: sandycheeks
+    image: gcr.io/cloud-builders/gcloud:latest
+    command: ["/bin/sleep"]
+    args:
+    - "100000"
+    volumeMounts:
+    - name: minecraft-map
+      mountPath: "/home/minecraft/server"
+      readOnly: false
+  volumes:
+  - name: minecraft-map
+    persistentVolumeClaim:
+      claimName: minecraft-map-volume
+EOF

--- a/k8s/ssd-claim.yml
+++ b/k8s/ssd-claim.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minecraft-map-volume
+spec:
+  storageClassName: minecraft-ssd
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/ssd.yml
+++ b/k8s/ssd.yml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: minecraft-ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Retain


### PR DESCRIPTION
This runs in k8s at `mc.dipshit.dev` now.

Uses ssd & pvc on preemptible nodes for that thicc discount